### PR TITLE
fix geolocation tracking for deployment

### DIFF
--- a/app/helpers.py
+++ b/app/helpers.py
@@ -1,3 +1,4 @@
+from fastapi import Request
 from app.models.shorturl import ShortURL
 import hashlib
 import logging
@@ -22,7 +23,13 @@ def generate_short_url(url: str) -> str:
 
     return short_url[:15]  # Ensure the length is within 15 characters
 
-async def get_geo_from_ip(ip_address: str, short_url_obj: ShortURL):
+def get_client_ip(request: Request):
+    x_forwarded_for = request.headers.get("x-forwarded-for")
+    if x_forwarded_for:
+        return x_forwarded_for.split(",")[0]
+    return request.client.host
+
+async def get_geo_from_ip(ip_address: str):
     ip_api_url = f"{IP_API}/{ip_address}"
     async with httpx.AsyncClient() as client:
         response = await client.get(ip_api_url)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,7 @@
-from app.helpers import generate_short_url
+from unittest.mock import MagicMock
+from app.helpers import generate_short_url, get_client_ip
+from starlette.datastructures import Headers
+from starlette.requests import Request
 
 def test_generate_short_url_basic():
     url = "https://www.example.com"
@@ -31,3 +34,17 @@ def test_generate_short_url_long_url():
     result = generate_short_url(url)
     assert result is not None, "The result should not be None for a long URL"
     assert len(result) <= 15, "The short URL for a long URL should be no longer than 15 characters"
+
+
+def test_get_client_ip_with_x_forwarded_for():
+    headers = Headers({'x-forwarded-for': '123.45.67.89, 98.76.54.32'})
+    request = Request(scope={'type': 'http', 'headers': headers.raw})
+    ip = get_client_ip(request)
+    assert ip == '123.45.67.89'
+
+def test_get_client_ip_without_x_forwarded_for():
+    request = MagicMock()
+    request.headers = {}
+    request.client.host = '98.76.54.32'
+    ip = get_client_ip(request)
+    assert ip == '98.76.54.32'


### PR DESCRIPTION
seems like Render has a proxy which masks the client's IP address. hope this will solve it